### PR TITLE
remove single quotes

### DIFF
--- a/parse_configs.sh
+++ b/parse_configs.sh
@@ -6,5 +6,5 @@ if [ -z ${SLACK_WEBHOOK_URL} ] || [ -z ${SLACK_CHANNEL} ] ;
     exit 1
 fi
 
-sed -i '' "s|__SLACK_WEBHOOK_URL__|${SLACK_WEBHOOK_URL}|g" config/alertmanager.yml
-sed -i '' "s|__SLACK_CHANNEL__|${SLACK_CHANNEL}|g" config/alertmanager.yml
+sed -i "s|__SLACK_WEBHOOK_URL__|${SLACK_WEBHOOK_URL}|g" config/alertmanager.yml
+sed -i "s|__SLACK_CHANNEL__|${SLACK_CHANNEL}|g" config/alertmanager.yml


### PR DESCRIPTION
Probably a typo, the single quotes make `sed` think the regex expression is the name of the file, and thus print this error:
```
sed: can't read s|__SLACK_WEBHOOK_URL__|https://hooks.slack.com/services/XXXXX9XXXXX/XXXXXXX|g: No such file or directory
sed: can't read s|__SLACK_CHANNEL__|#﻿XXXX-alerts|g: No such file or directory
```